### PR TITLE
Respect ReSTIR ray and sample budgets

### DIFF
--- a/modules/api/src/main/java/at/redi2go/photonics/api/shaders/PhotonicsProperties.java
+++ b/modules/api/src/main/java/at/redi2go/photonics/api/shaders/PhotonicsProperties.java
@@ -52,7 +52,7 @@ public interface PhotonicsProperties {
 
     int getRestirInitialSamples();
     int DEFAULT_RESTIR_INITIAL_SAMPLES = 32;
-    String RESTIR_INITIAL_SAMPLES_KEY = "photonics.resitrInitialSamples";
+    String RESTIR_INITIAL_SAMPLES_KEY = "photonics.restirInitialSamples";
 
     int getRestirSpatialReuseSamples();
     int DEFAULT_RESTIR_SPATIAL_REUSE_SAMPLES = 5;

--- a/modules/shaders/photonics/internal/tracing/simple.glsl
+++ b/modules/shaders/photonics/internal/tracing/simple.glsl
@@ -8,6 +8,8 @@ bool trace_light_vis(
 ) {
     RayIterator ray;
     ray_iter_begin(ray, rt_pos, direction);
+    ray.iterations = max(max_iterations, 0);
+
     RayResult result = missed_ray_result();
 
     vec4 running_tint_color = vec4(0);

--- a/modules/shaders/photonics/rendering/restir_di/restir.glsl
+++ b/modules/shaders/photonics/rendering/restir_di/restir.glsl
@@ -141,7 +141,7 @@ bool reservoir_update(
 }
 
 void reservoir_init(inout Reservoir reservoir, vec3 rt_pos) {
-    for (int i = 0; i < 32; i++) {
+    for (int i = 0; i < PH_RESTIR_INITIAL_SAMPLES; i++) {
         int rand_index = rand_next_int(frag_rnd_state, 0, light_list_size);
         LightSample smple = light_sample_new(light_list_get(rand_index), rt_pos);
 


### PR DESCRIPTION
## Summary
- cap light visibility rays with the max_iterations argument
- use PH_RESTIR_INITIAL_SAMPLES for initial reservoir sampling
- fix the ReSTIR initial samples property key typo

## Testing
- git diff --check
- ./gradlew.bat build (fails before compilation: Java 22 toolchain is not installed/configured on this machine)